### PR TITLE
chore: update package validation baseline to 0.1.0-preview.0.1.1

### DIFF
--- a/src/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations.csproj
+++ b/src/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.0.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.0.1.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations</PackageId>


### PR DESCRIPTION
## Summary

- Update `PackageValidationBaselineVersion` to `0.1.0-preview.0.1.1` to keep it in sync with the latest published tag.

## Test plan

- [ ] Build passes with updated baseline