### PR TITLE
Update package validation baseline to 0.1.0-preview.0.1.2

### DIFF
--- a/src/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations.csproj
+++ b/src/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations/Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.0.1.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.0.1.2</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.RichRelationalModel.EFCore.Models.Configurations</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.0.1.1` to `0.1.0-preview.0.1.2` following the successful publish.